### PR TITLE
Fixed regular expression case-insensitive modifier

### DIFF
--- a/tes3cmd
+++ b/tes3cmd
@@ -8655,7 +8655,7 @@ sub cmd_modify {
     my $modify_subrecords = ($opt_sub_match or $opt_sub_no_match);
     if (my $replacer = ($opt_modify_replace || $opt_modify_replacefirst)) {
 	# make the replacer case-insensitive
-	$replacer = qq{(?i)$replacer};
+	$replacer .= 'i';
 	if (not $opt_modify_replacefirst) {
 	    # make the replacer global
 	    $replacer .= 'g';


### PR DESCRIPTION
Replacer regular expressions have the form `/a/b/`, but the `(?i)` to indicate a pattern is case-insensitive needs to be part of the pattern, so prepending it to the expression is invalid.

This causes all `tes3cmd modify --replace` commands to fail, as the pattern is always invalid.

I've modified it to append `i` at the end since that's simpler than inserting it into the pattern.